### PR TITLE
Small changes to GraphicsManager and example program

### DIFF
--- a/KonsoleGameEngine/KonsoleGameEngine/KonsoleGameEngine/GraphicsManager.cs
+++ b/KonsoleGameEngine/KonsoleGameEngine/KonsoleGameEngine/GraphicsManager.cs
@@ -28,9 +28,9 @@ namespace KonsoleGameEngine
         /// Standard Ctor must accept a reference to GameWorld
         /// </summary>
         /// <param name="argGameWorld">GameWorld to be rendered</param>
-        public GraphicsManager(GameWorld argGameWorld)
+        public GraphicsManager(GameWorld argGameWorld, string title = "KonsoleGameEngine")
         {
-            Console.Title = "Space Invaders";
+            Console.Title = title;
             gameWorld = argGameWorld;
             Console.CursorVisible = false;
             Console.SetWindowSize(gameWorld.X + 2, gameWorld.Y + 1);

--- a/KonsoleGameEngine/KonsoleGameEngine/KonsoleGameEngine/GraphicsManager.cs
+++ b/KonsoleGameEngine/KonsoleGameEngine/KonsoleGameEngine/GraphicsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 
 namespace KonsoleGameEngine
 {
@@ -15,6 +16,11 @@ namespace KonsoleGameEngine
         /// Scene buffer to be drawn
         /// </summary>
         private string gameScene;
+
+        /// <summary>
+        /// String builder to construct the scene buffer
+        /// </summary>
+        private StringBuilder gameSceneBuilder;
         #endregion
 
         #region Ctors
@@ -30,6 +36,7 @@ namespace KonsoleGameEngine
             Console.SetWindowSize(gameWorld.X + 2, gameWorld.Y + 1);
             Console.BufferWidth = gameWorld.X + 2;
             Console.BufferHeight = gameWorld.Y + 1;
+            gameSceneBuilder = new StringBuilder(gameWorld.X * gameWorld.Y + 1);
         }
         #endregion
 
@@ -39,16 +46,17 @@ namespace KonsoleGameEngine
         /// </summary>
         public void Update()
         {
-            gameScene = "";
+            gameSceneBuilder.Clear();
             for (int y = 0; y < gameWorld.Y; y++)
             {
                 for (int x = 0; x < gameWorld.X; x++)
                 {
-                    gameScene += gameWorld.GetCellContents(x, y);
+                    gameSceneBuilder.Append(gameWorld.GetCellContents(x, y));
                 }
 
-                gameScene += "\n";
+                gameSceneBuilder.Append("\n");
             }
+            gameScene = gameSceneBuilder.ToString();
         }
 
         /// <summary>

--- a/KonsoleGameEngine/KonsoleGameEngine/Terrain.cs
+++ b/KonsoleGameEngine/KonsoleGameEngine/Terrain.cs
@@ -32,9 +32,22 @@ namespace MyGame
         {
             Random rng = new Random();
             Model = new List<Cell>();
-            for (int i = 0; i < 250; i++)
+            double fillPercent = .2;
+
+            for(int x = 0; x < 50; x++)
             {
-                Model.Add(new Cell(rng.Next(50), rng.Next(20), "█") { IsWalkable = false });
+                for(int y = 0; y < 20; y++)
+                {
+                    if(x < 3 && y < 3) //keep walls out of the starting area
+                    {
+                        continue;
+                    }
+
+                    if(rng.NextDouble() <= fillPercent)
+                    {
+                        Model.Add(new Cell(x, y, "█") { IsWalkable = false });
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The GraphicsManager.Update method now uses a StringBuilder instead of appending directly to the gameScene string.
The GraphicsManager ctor now takes a title string parameter instead of setting the console title to "Space Invaders". The parameter has a default value of "KonsoleGameEngine"

The example programs Terrain.Start method now uses a different algorithm that allows better control over how many walls should be placed (using the fillPercent variable) and keeps the walls out of the starting area in the top left. (The example program would throw an exception if no path could be found, i.e. when the starting position contained a wall and you pressed space while still inside the wall).